### PR TITLE
fix(watch): generate a new api client when retrying a watchfeed

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: etcd
-version: 1.0.1
+version: 1.0.2
 crystal: ~> 0.35
 
 authors:

--- a/spec/helper.cr
+++ b/spec/helper.cr
@@ -3,6 +3,11 @@ require "../src/etcd"
 require "../src/etcd/*"
 
 TEST_PREFIX = "test"
+
+Spec.before_suite do
+  Log.setup("*", level: Log::Severity::Debug)
+end
+
 Spec.before_each do
   begin
     Etcd.from_env.kv.delete_prefix TEST_PREFIX

--- a/src/etcd/model/watch.cr
+++ b/src/etcd/model/watch.cr
@@ -3,18 +3,20 @@ require "./kv"
 
 module Etcd::Model
   class WatchResponse < Base
-    getter result : WatchResult
+    getter result : WatchResult = Etcd::Model::WatchResult.new
     getter error : WatchError?
     getter created : Bool = false
   end
 
   class WatchError < Base
-    @[JSON::Field(converter: Etcd::Model::StringTypeConverter(Int32))]
     getter http_code : Int32
   end
 
   class WatchResult < Base
     getter events : Array(Etcd::Model::WatchEvent) = [] of Etcd::Model::WatchEvent
+
+    def initialize(@events = [] of Etcd::Model::WatchEvent)
+    end
   end
 
   class WatchEvent < Base


### PR DESCRIPTION
- Add logging when a new client is created in `Watcher`'s retry loop
- Removed spawn and captured block in `consume_io`, IO is now consumed synchronously