### PR TITLE
[FIX] raise on dead socket

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: etcd
-version: 1.0.2
+version: 1.0.3
 crystal: ~> 0.35
 
 authors:

--- a/src/etcd/watch.cr
+++ b/src/etcd/watch.cr
@@ -191,14 +191,10 @@ class Etcd::Watch
     protected def consume_io(io, tokenizer, &block : String -> Void)
       raw_data = Bytes.new(4096)
       while !io.closed?
-        begin
-          bytes_read = io.read(raw_data)
-          break if bytes_read == 0 # IO was closed
-          tokenizer.extract(raw_data[0, bytes_read]).each do |message|
-            yield String.new(message)
-          end
-        rescue e : Socket::Error
-          break
+        bytes_read = io.read(raw_data)
+        break if bytes_read == 0 # IO was closed
+        tokenizer.extract(raw_data[0, bytes_read]).each do |message|
+          yield String.new(message)
         end
       end
     end


### PR DESCRIPTION
Previously, errors produced on consuming tokens from a closed IO were swallowed, potentially leading to silent failures.