### PR TITLE
refactor(watcher): rely on tcp keepalive when listening for events

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: etcd
-version: 1.2.1
+version: 1.2.2
 crystal: ">= 0.35"
 license: MIT
 authors:


### PR DESCRIPTION
Could cause an issue in rare cases where TCP keepalive is not respected.

Closes #10 